### PR TITLE
Fix special characters in parsing serial numbers

### DIFF
--- a/src/SerialNumberGenerator.php
+++ b/src/SerialNumberGenerator.php
@@ -163,6 +163,8 @@ class SerialNumberGenerator implements GenerateSerialNumber
 
     protected function formatToRegex(): string
     {
+        $format = preg_replace('/([^\w\s])/i', '\\\\$1', $this->format);
+        
         $value = preg_replace_callback_array(
             [
                 '/P+/' => fn ($matches) => ($matches[0] && $length = mb_strlen($matches[0])) ? "(?<prefix>[a-zA-Z]{{$length}})" : '',
@@ -171,7 +173,7 @@ class SerialNumberGenerator implements GenerateSerialNumber
                 '/Y+/' => fn ($matches) => ($matches[0] && $length = mb_strlen($matches[0])) ? "(?<year>\d{{$length}})" : '',
                 '/C+/' => fn ($matches) => ($matches[0] && $length = mb_strlen($matches[0])) ? "(?<count>\d{{$length}})" : '',
             ],
-            $this->format
+            $format
         );
 
         return is_string($value) ? $value : '';


### PR DESCRIPTION
If the user uses "/" in the serial number format, preg_match can't parse the string as / is a delimiter for regex.
Escaping those characters should fix the problem.