### PR TITLE
Remove invalid alias for non-existent Invoice facade

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -88,10 +88,7 @@
         "laravel": {
             "providers": [
                 "Elegantly\\Invoices\\InvoiceServiceProvider"
-            ],
-            "aliases": {
-                "Invoice": "Elegantly\\Invoices\\Facades\\Invoice"
-            }
+            ]
         }
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
The `composer.json` file included an alias for `Invoice` to `Elegantly\Invoices\Facades\Invoice` in the `extra.laravel.aliases` section. However, the class `Elegantly\Invoices\Facades\Invoice` does not exist in the package, leading to errors when tools like `barryvdh/laravel-ide-helper` attempt to resolve it. This PR removes the invalid alias.